### PR TITLE
add variable expansion for PKG_CONFIG_PATH, used by pkg-config

### DIFF
--- a/packages/eigen/vars
+++ b/packages/eigen/vars
@@ -1,1 +1,2 @@
 INCLUDE = include
+PKG_CONFIG = share/pkgconfig

--- a/packages/glog/vars
+++ b/packages/glog/vars
@@ -1,6 +1,7 @@
 BIN = bin
 MAN = share/man
 INCLUDE = include
+PKG_CONFIG = lib/pkgconfig
 LIB = lib
 LIBS_CC = -lglog
 LIBS_CXX = -lglog

--- a/packages/wcslib/vars
+++ b/packages/wcslib/vars
@@ -1,6 +1,7 @@
 BIN = bin
 INCLUDE = include
 MAN = share/man
+PKG_CONFIG = lib/pkgconfig
 LIB = lib
 LIBS_CC = -lwcs
 LIBS_CXX = -lwcs

--- a/tools/HPCPorts.pm
+++ b/tools/HPCPorts.pm
@@ -34,6 +34,7 @@ sub standard_vars {
 		"BIN",
 		"MAN",
 		"PYTHON",
+		"PKG_CONFIG",
 		"INCLUDE",
 		"DATA",
 		"TCL",
@@ -639,6 +640,10 @@ sub module_file {
 			for $val ( @valsplit ) {
 				print OUT "prepend-path PYTHONPATH \"${prefix}/${pname}-${fullversion}/${val}/${pysite}/site-packages\"\n";
 			}
+		} elsif ( $key eq "PKG_CONFIG" ) {
+			for $val ( @valsplit ) {
+				print OUT "prepend-path PKG_CONFIG_PATH \"${prefix}/${pname}-${fullversion}/${val}\"\n";
+			}
 		} elsif ( $key eq "INCLUDE" ) {
 			for $val ( @valsplit ) {
 				print OUT "prepend-path CPATH \"${prefix}/${pname}-${fullversion}/${val}\"\n";
@@ -786,6 +791,10 @@ sub shell_file {
 			} elsif ( $key eq "PYTHON" ) {
 				for $val ( @valsplit ) {
 					print OUT "export PYTHONPATH=\"${prefix}/${pname}-${fullversion}/${val}/${pysite}/site-packages:\$PYTHONPATH\"\n";
+				}
+			} elsif ( $key eq "PKG_CONFIG" ) {
+				for $val ( @valsplit ) {
+					print OUT "export PKG_CONFIG_PATH=\"${prefix}/${pname}-${fullversion}/${val}:\$PKG_CONFIG_PATH\"\n";
 				}
 			} elsif ( $key eq "TCL" ) {
 				for $val ( @valsplit ) {


### PR DESCRIPTION
pkg-config is awesome for getting compile and link flags for packages; no need for super-long "make" commands that pass in all required variables.  This patch adds PKG_CONFIG variable expansion in HPCPorts.pm.
