### PR TITLE
add setuptools as dependency of astropy

### DIFF
--- a/packages/astropy/deps
+++ b/packages/astropy/deps
@@ -1,1 +1,1 @@
-numpy cfitsio expat cython
+setuptools numpy cfitsio expat cython


### PR DESCRIPTION
I was getting the following with an "hpcp install astropy" while trying to build up an edison CCM-mode install.  Adding 'setuptools' as as dep of astropy seems to fix it.


The required version of setuptools (>=1.4.2) is not available,
and can't be installed while this script is running. Please
install a more recent version first, using
'easy_install -U setuptools'.

(Currently using setuptools 0.6c11 (/global/common/edison/usg/altd/2.0/lib64/python2.6/site-packages/setuptools-0.6c11-py2.6.egg))
make[2]: *** [pkg-build] Error 2
make[2]: Leaving directory `/global/u1/d/dstn/hpcports/packages/astropy'
