### PR TITLE
Override variables

### DIFF
--- a/system/ubuntu-15.10.make.in
+++ b/system/ubuntu-15.10.make.in
@@ -76,6 +76,21 @@ lapack_LIBS_CXX = $(lapack_LIBS_CC)
 lapack_LIBS_F77 = $(lapack_LIBS_CC)
 lapack_LIBS_FC = $(lapack_LIBS_CC)
 
+cfitsio_LIBS_CC = -lcfitsio
+cfitsio_LIBS_CXX = $(cfitsio_LIBS_CC)
+cfitsio_LIBS_F77 = $(cfitsio_LIBS_CC)
+cfitsio_LIBS_FC = $(cfitsio_LIBS_CC)
+
+fftw_LIBS_CC = -lfftw3_threads -lfftw3
+fftw_LIBS_CXX = $(fftw_LIBS_CC)
+fftw_LIBS_F77 = $(fftw_LIBS_CC)
+fftw_LIBS_FC = $(fftw_LIBS_CC)
+
+fftw_LIBS_MPICC = -lfftw3_mpi
+fftw_LIBS_MPICXX = $(fftw_LIBS_MPICC)
+fftw_LIBS_MPIF77 = $(fftw_LIBS_MPICC)
+fftw_LIBS_MPIFC = $(fftw_LIBS_MPICC)
+
 termcap_OVERRIDE = TRUE
 termcap_VERSION = sys
 

--- a/tools/HPCPorts.pm
+++ b/tools/HPCPorts.pm
@@ -509,6 +509,9 @@ sub config_vars {
 
 	my $varstore = {};
 
+	my @override_names = ();
+	my @override_values = ();
+
 	while ( <IN> ) {
 		chomp;
 		if ( ( ! /^#.*/ ) && ( $_ ne "" ) ) {
@@ -534,17 +537,23 @@ sub config_vars {
 			} elsif ( ( /^(.*)_OVERRIDE.*/ ) && ( $explhs eq "TRUE" ) ) {
 				$overrides->{ $1 } = {};
 			} else {
-				# scan for package variables
-				my $key;
-				my $value;
-				foreach $key ( keys %{$overrides} ) {
-					$value = $overrides->{ $key };
-					if ( $F[0] =~ /${key}_(.*)/ ) {
-						$value->{ $1 } = $explhs;
-					}
-				}
+			        push ( @override_names, $F[0] );
+			        push ( @override_values, $explhs );
 			}
 		}
+	}
+
+	# scan for package variables
+	my $n = @override_names;
+	for ( my $i = 0; $i < $n; $i++ ) {
+	    my $key;
+	    my $value;
+	    foreach $key ( keys %{$overrides} ) {
+		$value = $overrides->{ $key };
+		if ( $override_names[$i] =~ /${key}_(.*)/ ) {
+		    $value->{ $1 } = $override_values[$i];
+		}
+	    }
 	}
 
 	if ( $env eq "" ) {


### PR DESCRIPTION
Some of the override variables did not get parsed correctly if the override=True line was after the other lines in the config file. Modified the config file parsing to delay parsing of the overrides only after the entire file is read.